### PR TITLE
Switch to DB user store

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
-# test5
+# Demo Authorization Server
+
+This project demonstrates a minimal Spring Authorization Server configuration
+backed by a simple H2 database. Default credentials are loaded on startup and
+can be used by other microservices to obtain OAuth2 tokens.
+
+```
+username: user
+password: password
+```
+
+Other services can validate issued JWT tokens using the exposed JWK endpoint.

--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,8 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter'
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-authorization-server'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    runtimeOnly 'com.h2database:h2'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }

--- a/src/main/java/com/example/demo/config/AuthorizationServerConfig.java
+++ b/src/main/java/com/example/demo/config/AuthorizationServerConfig.java
@@ -11,11 +11,8 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.oauth2.server.authorization.config.annotation.web.configuration.OAuth2AuthorizationServerConfiguration;
-import org.springframework.security.core.userdetails.User;
-import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.factory.PasswordEncoderFactories;
 import org.springframework.security.crypto.password.PasswordEncoder;
-import org.springframework.security.provisioning.InMemoryUserDetailsManager;
 import org.springframework.security.oauth2.core.AuthorizationGrantType;
 import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
 import org.springframework.security.oauth2.core.oidc.OidcScopes;
@@ -89,12 +86,7 @@ public class AuthorizationServerConfig {
     }
 
     @Bean
-    public UserDetailsService userDetailsService() {
-        PasswordEncoder encoder = PasswordEncoderFactories.createDelegatingPasswordEncoder();
-        var user = User.withUsername("user")
-                .password(encoder.encode("password"))
-                .roles("USER")
-                .build();
-        return new InMemoryUserDetailsManager(user);
+    public PasswordEncoder passwordEncoder() {
+        return PasswordEncoderFactories.createDelegatingPasswordEncoder();
     }
 }

--- a/src/main/java/com/example/demo/user/DataInitializer.java
+++ b/src/main/java/com/example/demo/user/DataInitializer.java
@@ -1,0 +1,25 @@
+package com.example.demo.user;
+
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.factory.PasswordEncoderFactories;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class DataInitializer {
+
+    @Bean
+    CommandLineRunner initUsers(UserRepository repository) {
+        PasswordEncoder encoder = PasswordEncoderFactories.createDelegatingPasswordEncoder();
+        return args -> {
+            if (repository.count() == 0) {
+                UserEntity user = new UserEntity();
+                user.setUsername("user");
+                user.setPassword(encoder.encode("password"));
+                user.setRoles("USER");
+                repository.save(user);
+            }
+        };
+    }
+}

--- a/src/main/java/com/example/demo/user/DatabaseUserDetailsService.java
+++ b/src/main/java/com/example/demo/user/DatabaseUserDetailsService.java
@@ -1,0 +1,29 @@
+package com.example.demo.user;
+
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+public class DatabaseUserDetailsService implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    public DatabaseUserDetailsService(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        UserEntity user = userRepository.findByUsername(username)
+                .orElseThrow(() -> new UsernameNotFoundException("User not found"));
+
+        String[] roles = user.getRoles() == null ? new String[]{} : user.getRoles().split(",");
+        return User.withUsername(user.getUsername())
+                   .password(user.getPassword())
+                   .roles(roles)
+                   .build();
+    }
+}

--- a/src/main/java/com/example/demo/user/UserEntity.java
+++ b/src/main/java/com/example/demo/user/UserEntity.java
@@ -1,0 +1,50 @@
+package com.example.demo.user;
+
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "users")
+public class UserEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(unique = true)
+    private String username;
+
+    private String password;
+
+    private String roles;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    public String getRoles() {
+        return roles;
+    }
+
+    public void setRoles(String roles) {
+        this.roles = roles;
+    }
+}

--- a/src/main/java/com/example/demo/user/UserRepository.java
+++ b/src/main/java/com/example/demo/user/UserRepository.java
@@ -1,0 +1,9 @@
+package com.example.demo.user;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<UserEntity, Long> {
+    Optional<UserEntity> findByUsername(String username);
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,7 @@
 spring.application.name=demo
+spring.datasource.url=jdbc:h2:mem:testdb
+spring.datasource.driverClassName=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+spring.jpa.hibernate.ddl-auto=update
+spring.h2.console.enabled=true


### PR DESCRIPTION
## Summary
- store user details using Spring Data JPA
- add H2 and JPA dependencies
- seed a default user on startup
- expose a password encoder bean
- document how to use this authorization server

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_6876485d25e483318d8cd72eb2ed7c8b