### PR TITLE
Add database-backed OAuth server with management APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # Demo Authorization Server
 
 This project demonstrates a minimal Spring Authorization Server configuration
-backed by a simple H2 database. Default credentials are loaded on startup and
-can be used by other microservices to obtain OAuth2 tokens.
+backed by an H2 database. Default credentials are loaded on startup and
+can be used by other microservices to obtain OAuth2 tokens. Users and OAuth clients
+are stored in the database so that new ones can be created at runtime.
 
 ```
 username: user
@@ -10,3 +11,33 @@ password: password
 ```
 
 Other services can validate issued JWT tokens using the exposed JWK endpoint.
+
+## Managing Users
+
+The server exposes REST endpoints to create and update users:
+
+```bash
+curl -X POST http://localhost:8080/users \
+    -H 'Content-Type: application/json' \
+    -d '{"username":"api","password":"secret","roles":"USER"}'
+
+curl http://localhost:8080/users
+```
+
+## Managing OAuth Clients
+
+Clients are also persisted and can be created via the `/clients` endpoint:
+
+```bash
+curl -X POST http://localhost:8080/clients \
+    -H 'Content-Type: application/json' \
+    -d '{"id":"1","clientId":"my-client","clientSecret":"my-secret","redirectUri":"http://localhost:8080/login/oauth2/code/my-client"}'
+```
+
+After registering a client, obtain a token using the standard OAuth2 Authorization Code flow.
+
+Run the application using:
+
+```bash
+./gradlew bootRun
+```

--- a/src/main/java/com/example/demo/client/ClientController.java
+++ b/src/main/java/com/example/demo/client/ClientController.java
@@ -1,0 +1,67 @@
+package com.example.demo.client;
+
+import java.util.List;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.security.oauth2.core.AuthorizationGrantType;
+import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
+import org.springframework.security.oauth2.server.authorization.client.RegisteredClient;
+import org.springframework.security.oauth2.server.authorization.client.RegisteredClientRepository;
+import org.springframework.security.oauth2.server.authorization.settings.ClientSettings;
+import org.springframework.security.oauth2.server.authorization.settings.TokenSettings;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/clients")
+public class ClientController {
+
+    private final RegisteredClientRepository clientRepository;
+    private final JdbcTemplate jdbcTemplate;
+
+    public ClientController(RegisteredClientRepository clientRepository, JdbcTemplate jdbcTemplate) {
+        this.clientRepository = clientRepository;
+        this.jdbcTemplate = jdbcTemplate;
+    }
+
+    @GetMapping
+    public List<String> listClients() {
+        return jdbcTemplate.queryForList("select client_id from oauth2_registered_client", String.class);
+    }
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public void create(@RequestBody ClientRequest request) {
+        RegisteredClient registeredClient = RegisteredClient.withId(request.id())
+                .clientId(request.clientId())
+                .clientSecret(request.clientSecret())
+                .clientAuthenticationMethod(ClientAuthenticationMethod.CLIENT_SECRET_BASIC)
+                .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
+                .authorizationGrantType(AuthorizationGrantType.REFRESH_TOKEN)
+                .redirectUri(request.redirectUri())
+                .scope("read")
+                .clientSettings(ClientSettings.builder().build())
+                .tokenSettings(TokenSettings.builder().build())
+                .build();
+        clientRepository.save(registeredClient);
+    }
+
+    @GetMapping("/{clientId}")
+    public RegisteredClient getByClientId(@PathVariable String clientId) {
+        return clientRepository.findByClientId(clientId);
+    }
+
+    @PutMapping("/{clientId}")
+    public void update(@PathVariable String clientId, @RequestBody RegisteredClient client) {
+        clientRepository.save(client);
+    }
+
+    public record ClientRequest(String id, String clientId, String clientSecret, String redirectUri) {}
+}

--- a/src/main/java/com/example/demo/config/AuthorizationServerConfig.java
+++ b/src/main/java/com/example/demo/config/AuthorizationServerConfig.java
@@ -17,8 +17,9 @@ import org.springframework.security.oauth2.core.AuthorizationGrantType;
 import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
 import org.springframework.security.oauth2.core.oidc.OidcScopes;
 import org.springframework.security.oauth2.server.authorization.client.RegisteredClient;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.security.oauth2.server.authorization.client.RegisteredClientRepository;
-import org.springframework.security.oauth2.server.authorization.client.InMemoryRegisteredClientRepository;
+import org.springframework.security.oauth2.server.authorization.client.JdbcRegisteredClientRepository;
 import org.springframework.security.web.SecurityFilterChain;
 
 import com.nimbusds.jose.jwk.JWKSet;
@@ -36,18 +37,25 @@ public class AuthorizationServerConfig {
     }
 
     @Bean
-    public RegisteredClientRepository registeredClientRepository() {
-        RegisteredClient registeredClient = RegisteredClient.withId(UUID.randomUUID().toString())
-                .clientId("demo-client")
-                .clientSecret("{noop}demo-secret")
-                .clientAuthenticationMethod(ClientAuthenticationMethod.CLIENT_SECRET_BASIC)
-                .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
-                .authorizationGrantType(AuthorizationGrantType.REFRESH_TOKEN)
-                .redirectUri("http://localhost:8080/login/oauth2/code/demo-client")
-                .scope(OidcScopes.OPENID)
-                .scope("read")
-                .build();
-        return new InMemoryRegisteredClientRepository(registeredClient);
+    public RegisteredClientRepository registeredClientRepository(JdbcTemplate jdbcTemplate,
+            PasswordEncoder passwordEncoder) {
+        JdbcRegisteredClientRepository repository = new JdbcRegisteredClientRepository(jdbcTemplate);
+
+        if (repository.findByClientId("demo-client") == null) {
+            RegisteredClient registeredClient = RegisteredClient.withId(UUID.randomUUID().toString())
+                    .clientId("demo-client")
+                    .clientSecret(passwordEncoder.encode("demo-secret"))
+                    .clientAuthenticationMethod(ClientAuthenticationMethod.CLIENT_SECRET_BASIC)
+                    .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
+                    .authorizationGrantType(AuthorizationGrantType.REFRESH_TOKEN)
+                    .redirectUri("http://localhost:8080/login/oauth2/code/demo-client")
+                    .scope(OidcScopes.OPENID)
+                    .scope("read")
+                    .build();
+            repository.save(registeredClient);
+        }
+
+        return repository;
     }
 
     @Bean

--- a/src/main/java/com/example/demo/user/UserController.java
+++ b/src/main/java/com/example/demo/user/UserController.java
@@ -1,0 +1,55 @@
+package com.example.demo.user;
+
+import java.util.List;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/users")
+public class UserController {
+
+    private final UserRepository repository;
+    private final PasswordEncoder passwordEncoder;
+
+    public UserController(UserRepository repository, PasswordEncoder passwordEncoder) {
+        this.repository = repository;
+        this.passwordEncoder = passwordEncoder;
+    }
+
+    @GetMapping
+    public List<UserEntity> list() {
+        return repository.findAll();
+    }
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public UserEntity create(@RequestBody UserEntity user) {
+        user.setPassword(passwordEncoder.encode(user.getPassword()));
+        return repository.save(user);
+    }
+
+    @GetMapping("/{id}")
+    public UserEntity get(@PathVariable Long id) {
+        return repository.findById(id).orElseThrow();
+    }
+
+    @PutMapping("/{id}")
+    public UserEntity update(@PathVariable Long id, @RequestBody UserEntity user) {
+        UserEntity existing = repository.findById(id).orElseThrow();
+        existing.setUsername(user.getUsername());
+        if (user.getPassword() != null) {
+            existing.setPassword(passwordEncoder.encode(user.getPassword()));
+        }
+        existing.setRoles(user.getRoles());
+        return repository.save(existing);
+    }
+}

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -1,0 +1,65 @@
+CREATE TABLE oauth2_registered_client (
+    id varchar(100) NOT NULL,
+    client_id varchar(100) NOT NULL,
+    client_id_issued_at timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    client_secret varchar(200) DEFAULT NULL,
+    client_secret_expires_at timestamp DEFAULT NULL,
+    client_name varchar(200) NOT NULL,
+    client_authentication_methods varchar(1000) NOT NULL,
+    authorization_grant_types varchar(1000) NOT NULL,
+    redirect_uris varchar(1000) DEFAULT NULL,
+    post_logout_redirect_uris varchar(1000) DEFAULT NULL,
+    scopes varchar(1000) NOT NULL,
+    client_settings varchar(2000) NOT NULL,
+    token_settings varchar(2000) NOT NULL,
+    PRIMARY KEY (id)
+);
+
+CREATE TABLE oauth2_authorization_consent (
+    registered_client_id varchar(100) NOT NULL,
+    principal_name varchar(200) NOT NULL,
+    authorities varchar(1000) NOT NULL,
+    PRIMARY KEY (registered_client_id, principal_name)
+);
+
+/*
+IMPORTANT:
+    If using PostgreSQL, update ALL columns defined with 'blob' to 'text',
+    as PostgreSQL does not support the 'blob' data type.
+*/
+CREATE TABLE oauth2_authorization (
+    id varchar(100) NOT NULL,
+    registered_client_id varchar(100) NOT NULL,
+    principal_name varchar(200) NOT NULL,
+    authorization_grant_type varchar(100) NOT NULL,
+    authorized_scopes varchar(1000) DEFAULT NULL,
+    attributes blob DEFAULT NULL,
+    state varchar(500) DEFAULT NULL,
+    authorization_code_value blob DEFAULT NULL,
+    authorization_code_issued_at timestamp DEFAULT NULL,
+    authorization_code_expires_at timestamp DEFAULT NULL,
+    authorization_code_metadata blob DEFAULT NULL,
+    access_token_value blob DEFAULT NULL,
+    access_token_issued_at timestamp DEFAULT NULL,
+    access_token_expires_at timestamp DEFAULT NULL,
+    access_token_metadata blob DEFAULT NULL,
+    access_token_type varchar(100) DEFAULT NULL,
+    access_token_scopes varchar(1000) DEFAULT NULL,
+    oidc_id_token_value blob DEFAULT NULL,
+    oidc_id_token_issued_at timestamp DEFAULT NULL,
+    oidc_id_token_expires_at timestamp DEFAULT NULL,
+    oidc_id_token_metadata blob DEFAULT NULL,
+    refresh_token_value blob DEFAULT NULL,
+    refresh_token_issued_at timestamp DEFAULT NULL,
+    refresh_token_expires_at timestamp DEFAULT NULL,
+    refresh_token_metadata blob DEFAULT NULL,
+    user_code_value blob DEFAULT NULL,
+    user_code_issued_at timestamp DEFAULT NULL,
+    user_code_expires_at timestamp DEFAULT NULL,
+    user_code_metadata blob DEFAULT NULL,
+    device_code_value blob DEFAULT NULL,
+    device_code_issued_at timestamp DEFAULT NULL,
+    device_code_expires_at timestamp DEFAULT NULL,
+    device_code_metadata blob DEFAULT NULL,
+    PRIMARY KEY (id)
+);


### PR DESCRIPTION
## Summary
- switch to JdbcRegisteredClientRepository so OAuth clients persist in the database
- add REST endpoints for managing users and OAuth clients
- store OAuth-related tables using `schema.sql`
- document new user and client APIs in README

## Testing
- `./gradlew build`

------
https://chatgpt.com/codex/tasks/task_e_68764b6cb58c83319f8ee44e2bb653ce